### PR TITLE
Support non-value attributes in HTML5 by setting their value to True, not ''

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -17,7 +17,7 @@ def _process_field_attributes(field, attr, process):
     # split attribute name and value from 'attr:value' string
     params = attr.split(':', 1)
     attribute = params[0]
-    value = params[1] if len(params) == 2 else ''
+    value = params[1] if len(params) == 2 else True
 
     # decorate field.as_widget method with updated attributes
     old_as_widget = field.as_widget

--- a/widget_tweaks/tests.py
+++ b/widget_tweaks/tests.py
@@ -330,3 +330,18 @@ class RenderFieldFilter_field_type_widget_type_Test(TestCase):
     def test_field_type_widget_type_rendering_simple(self):
         res = render_form('<div class="{{ form.simple|field_type }} {{ form.simple|widget_type }} {{ form.simple.html_name }}">{{ form.simple }}</div>')
         assertIn('class="charfield textinput simple"', res)
+
+
+class RenderFieldTagNonValueAttribute(TestCase):
+    def test_field_non_value(self):
+        res = render_form("{{ form.simple|attr:'required' }}", form=MyForm({}))
+        assertIn('required', res)
+        assertNotIn('required=', res)
+
+    def test_field_empty_value(self):
+        res = render_form("{{ form.simple|attr:'required:' }}", form=MyForm({}))
+        assertIn('required=""', res)
+
+    def test_field_other_value(self):
+        res = render_form("{{ form.simple|attr:'required:spam' }}", form=MyForm({}))
+        assertIn('required="spam"', res)


### PR DESCRIPTION
This will change the following:

```
{{ form.field1|attr:'required' }}
```

From:

``` html
<input ... required="">
```

To:

``` html
<input ... required>
```

The former can still be generated by writing:

```
{{ form.field1|attr:'required:' }} 
```

This is the same exact change that I created in the pull request in bitbucket, which you asked me to create here in github instead. I also added test cases per your request, which I hope you will find satisfactory.

Cheers!
