### PR TITLE
accept single quote inside values for render_field

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -118,9 +118,7 @@ ATTRIBUTE_RE = re.compile(r"""
         \+?=
     )
     (?P<value>
-    ['"]? # start quote
-        [^"']*
-    ['"]? # end quote
+        .*
     )
 """, re.VERBOSE | re.UNICODE)
 


### PR DESCRIPTION
Patch for kmike/django-widget-tweaks#26

I ran the tests and they all passed.

(first pull request ever, sorry if I did it wrong)
