### PR TITLE
Allow escaping of `:` character when processing field attributes

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -16,8 +16,8 @@ def silence_without_field(fn):
 def _process_field_attributes(field, attr, process):
 
     # split attribute name and value from 'attr:value' string
-    params = attr.split(':', 1)
-    attribute = params[0]
+    params = re.split(r'(?<!:):(?!:)', attr, 1)
+    attribute = params[0].replace('::', ':')
     value = params[1] if len(params) == 2 else ''
 
     field = copy(field)


### PR DESCRIPTION
Currently, the `attr` and similar filters simply split the argument into attribute name and attribute value by `:`. This is fine in most cases, however it could sometimes be desirable to be able to insert a `:` inside of the name of the attribute (for example, using [Vue.js](https://vuejs.org/) requires this functionality). For this reason, I made it so that a string like `b:d` gets split into `b` and `d`, but a string like `b::c:d` gets split into `b:c` and `d`.