### PR TITLE
Support paramater-less attributes in HTML5. e.g., <input foo> instead of <input foo="">

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -18,7 +18,7 @@ def _process_field_attributes(field, attr, process):
     # split attribute name and value from 'attr:value' string
     params = attr.split(':', 1)
     attribute = params[0]
-    value = params[1] if len(params) == 2 else ''
+    value = params[1] if len(params) == 2 else True
 
     field = copy(field)
 

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -1,14 +1,8 @@
 import re
 import types
 from copy import copy
-import django
 from django.template import Library, Node, TemplateSyntaxError
-from django.utils.safestring import mark_safe
-
 register = Library()
-
-
-BACKWARDS_COMPATIBILITY = django.VERSION[:2] < (1, 8)
 
 
 def silence_without_field(fn):
@@ -25,8 +19,6 @@ def _process_field_attributes(field, attr, process):
     params = attr.split(':', 1)
     attribute = params[0]
     value = params[1] if len(params) == 2 else True
-    if BACKWARDS_COMPATIBILITY and value is True:
-        value = '__BACKWARDS_COMPATIBILITY__'
 
     field = copy(field)
 
@@ -37,8 +29,6 @@ def _process_field_attributes(field, attr, process):
         attrs = attrs or {}
         process(widget or self.field.widget, attrs, attribute, value)
         html = old_as_widget(widget, attrs, only_initial)
-        if BACKWARDS_COMPATIBILITY:
-            html = mark_safe(html.replace('="__BACKWARDS_COMPATIBILITY__"', ''))
         self.as_widget = old_as_widget
         return html
 

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -1,8 +1,14 @@
 import re
 import types
 from copy import copy
+import django
 from django.template import Library, Node, TemplateSyntaxError
+from django.utils.safestring import mark_safe
+
 register = Library()
+
+
+BACKWARDS_COMPATIBILITY = django.VERSION[:2] < (1, 8)
 
 
 def silence_without_field(fn):
@@ -19,6 +25,8 @@ def _process_field_attributes(field, attr, process):
     params = attr.split(':', 1)
     attribute = params[0]
     value = params[1] if len(params) == 2 else True
+    if BACKWARDS_COMPATIBILITY and value is True:
+        value = '__BACKWARDS_COMPATIBILITY__'
 
     field = copy(field)
 
@@ -29,6 +37,8 @@ def _process_field_attributes(field, attr, process):
         attrs = attrs or {}
         process(widget or self.field.widget, attrs, attribute, value)
         html = old_as_widget(widget, attrs, only_initial)
+        if BACKWARDS_COMPATIBILITY:
+            html = mark_safe(html.replace('="__BACKWARDS_COMPATIBILITY__"', ''))
         self.as_widget = old_as_widget
         return html
 

--- a/widget_tweaks/tests.py
+++ b/widget_tweaks/tests.py
@@ -378,3 +378,18 @@ class RenderFieldFilter_field_type_widget_type_Test(TestCase):
     def test_field_type_widget_type_rendering_simple(self):
         res = render_form('<div class="{{ form.simple|field_type }} {{ form.simple|widget_type }} {{ form.simple.html_name }}">{{ form.simple }}</div>')
         assertIn('class="charfield textinput simple"', res)
+
+
+class RenderFieldTagNonValueAttribute(TestCase):
+    def test_field_non_value(self):
+        res = render_form("{{ form.simple|attr:'required' }}", form=MyForm({}))
+        assertIn('required', res)
+        assertNotIn('required=', res)
+
+    def test_field_empty_value(self):
+        res = render_form("{{ form.simple|attr:'required:' }}", form=MyForm({}))
+        assertIn('required=""', res)
+
+    def test_field_other_value(self):
+        res = render_form("{{ form.simple|attr:'required:spam' }}", form=MyForm({}))
+        assertIn('required="spam"', res)

--- a/widget_tweaks/tests.py
+++ b/widget_tweaks/tests.py
@@ -382,14 +382,14 @@ class RenderFieldFilter_field_type_widget_type_Test(TestCase):
 
 class RenderFieldTagNonValueAttribute(TestCase):
     def test_field_non_value(self):
-        res = render_form("{{ form.simple|attr:'required' }}", form=MyForm({}))
-        assertIn('required', res)
-        assertNotIn('required=', res)
+        res = render_form('{{ form.simple|attr:"foo" }}')
+        assertIn('foo', res)
+        assertNotIn('foo=', res)
 
     def test_field_empty_value(self):
-        res = render_form("{{ form.simple|attr:'required:' }}", form=MyForm({}))
-        assertIn('required=""', res)
+        res = render_form('{{ form.simple|attr:"foo:" }}')
+        assertIn('foo=""', res)
 
     def test_field_other_value(self):
-        res = render_form("{{ form.simple|attr:'required:spam' }}", form=MyForm({}))
-        assertIn('required="spam"', res)
+        res = render_form('{{ form.simple|attr:"foo:bar" }}')
+        assertIn('foo="bar"', res)


### PR DESCRIPTION
This PR makes the following change:

The template code `{{ form.field1|attr:"foo" }}` will output `<input … foo>` instead of `<input … foo="">`

The former can still be generated by writing `{{ form.field1|attr:"foo:" }}`

(redo of PR #22)