### PR TITLE
Colon escaping

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -14,11 +14,14 @@ def silence_without_field(fn):
 
 
 def _process_field_attributes(field, attr, process):
+    colon_special = '&colon;'
 
     # split attribute name and value from 'attr:value' string
+    attr.replace('\\:', colon_special)
     params = attr.split(':', 1)
-    attribute = params[0]
-    value = params[1] if len(params) == 2 else True
+
+    attribute = params[0].replace(colon_special, ':')
+    value = params[1].replace(colon_special, ':') if len(params) == 2 else True
 
     field = copy(field)
 

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -17,7 +17,7 @@ def _process_field_attributes(field, attr, process):
     colon_special = '&colon;'
 
     # split attribute name and value from 'attr:value' string
-    attr.replace('\\:', colon_special)
+    attr = attr.replace('\\:', colon_special)
     params = attr.split(':', 1)
 
     attribute = params[0].replace(colon_special, ':')


### PR DESCRIPTION
# Escaping colons
The problem was that we could not bring colon itself in attribute key or values. Imagine this Vue.js code:
```
<div v-bind:class="{ active: isActive }"></div>
```
we need to have some way to escape colon. This branch provides it by `\:`.
We can rewrite the above code in `widget-tweaks` with:
```
<form.cusom_input|attr:"v-bind\:class:{ active: isActive }"></div>
```

