### PR TITLE
add a params to run tests only for single test (faster development)

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -21,4 +21,5 @@ settings.configure(**opts)
 django.setup()
 
 if __name__ == "__main__":
-    call_command('test', 'widget_tweaks', verbosity=2)
+    param = "" if not len(sys.argv) >= 2  else "." +str(sys.argv[1])
+    call_command('test', 'widget_tweaks{}'.format(param), verbosity=2)


### PR DESCRIPTION
example:

`tox -e py36-django-20 --  tests.RenderFieldTagFieldReuseTest.test_field_datetime_widget`