### PR TITLE
Reformat code with black for PEP8 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 
 [testenv]
 deps =
+    {py36,py37}: black
     coverage
     django-18: Django>=1.8,<1.9
     django-111: Django>=1.11,<2.0
@@ -21,5 +22,6 @@ ignore_outcome =
     django-master: True
 commands =
     ./runtests.py {posargs}
+    !py27: black -t py27 --check --diff widget_tweaks
 setenv =
     PYTHONDONTWRITEBYTECODE=1

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -2,6 +2,7 @@ import re
 import types
 from copy import copy
 from django.template import Library, Node, TemplateSyntaxError
+
 register = Library()
 
 
@@ -10,6 +11,7 @@ def silence_without_field(fn):
         if not field:
             return ""
         return fn(field, attr)
+
     return wrapped
 
 
@@ -17,13 +19,14 @@ def _process_field_attributes(field, attr, process):
     # split attribute name and value from 'attr:value' string
     # params = attr.split(':', 1)
     # attribute = params[0]
-    params = re.split(r'(?<!:):(?!:)', attr, 1)
+    params = re.split(r"(?<!:):(?!:)", attr, 1)
     # attribute = params[0]
-    attribute = params[0].replace('::', ':')
+    attribute = params[0].replace("::", ":")
     value = params[1] if len(params) == 2 else True
     field = copy(field)
     # decorate field.as_widget method with updated attributes
     old_as_widget = field.as_widget
+
     def as_widget(self, widget=None, attrs=None, only_initial=False):
         attrs = attrs or {}
         process(widget or self.field.widget, attrs, attribute, value)
@@ -33,6 +36,7 @@ def _process_field_attributes(field, attr, process):
         html = old_as_widget(widget, attrs, only_initial)
         self.as_widget = old_as_widget
         return html
+
     field.as_widget = types.MethodType(as_widget, field)
     return field
 
@@ -40,16 +44,16 @@ def _process_field_attributes(field, attr, process):
 @register.filter("attr")
 @silence_without_field
 def set_attr(field, attr):
-
     def process(widget, attrs, attribute, value):
         attrs[attribute] = value
+
     return _process_field_attributes(field, attr, process)
 
 
 @register.filter("add_error_attr")
 @silence_without_field
 def add_error_attr(field, attr):
-    if hasattr(field, 'errors') and field.errors:
+    if hasattr(field, "errors") and field.errors:
         return set_attr(field, attr)
     return field
 
@@ -59,30 +63,31 @@ def add_error_attr(field, attr):
 def append_attr(field, attr):
     def process(widget, attrs, attribute, value):
         if attrs.get(attribute):
-            attrs[attribute] += ' ' + value
+            attrs[attribute] += " " + value
         elif widget.attrs.get(attribute):
-            attrs[attribute] = widget.attrs[attribute] + ' ' + value
+            attrs[attribute] = widget.attrs[attribute] + " " + value
         else:
             attrs[attribute] = value
+
     return _process_field_attributes(field, attr, process)
 
 
 @register.filter("add_class")
 @silence_without_field
 def add_class(field, css_class):
-    return append_attr(field, 'class:' + css_class)
+    return append_attr(field, "class:" + css_class)
 
 
 @register.filter("add_label_class")
 @silence_without_field
 def add_label_class(field, css_class):
-    return field.label_tag(attrs={'class': css_class})
+    return field.label_tag(attrs={"class": css_class})
 
 
 @register.filter("add_error_class")
 @silence_without_field
 def add_error_class(field, css_class):
-    if hasattr(field, 'errors') and field.errors:
+    if hasattr(field, "errors") and field.errors:
         return add_class(field, css_class)
     return field
 
@@ -90,36 +95,41 @@ def add_error_class(field, css_class):
 @register.filter("set_data")
 @silence_without_field
 def set_data(field, data):
-    return set_attr(field, 'data-' + data)
+    return set_attr(field, "data-" + data)
 
 
-@register.filter(name='field_type')
+@register.filter(name="field_type")
 def field_type(field):
     """
     Template filter that returns field class name (in lower case).
     E.g. if field is CharField then {{ field|field_type }} will
     return 'charfield'.
     """
-    if hasattr(field, 'field') and field.field:
+    if hasattr(field, "field") and field.field:
         return field.field.__class__.__name__.lower()
-    return ''
+    return ""
 
 
-@register.filter(name='widget_type')
+@register.filter(name="widget_type")
 def widget_type(field):
     """
     Template filter that returns field widget class name (in lower case).
     E.g. if field's widget is TextInput then {{ field|widget_type }} will
     return 'textinput'.
     """
-    if hasattr(field, 'field') and hasattr(field.field, 'widget') and field.field.widget:
+    if (
+        hasattr(field, "field")
+        and hasattr(field.field, "widget")
+        and field.field.widget
+    ):
         return field.field.widget.__class__.__name__.lower()
-    return ''
+    return ""
 
 
 # ======================== render_field tag ==============================
 
-ATTRIBUTE_RE = re.compile(r"""
+ATTRIBUTE_RE = re.compile(
+    r"""
     (?P<attr>
         [@\w:_-]+
     )
@@ -131,7 +141,9 @@ ATTRIBUTE_RE = re.compile(r"""
         [^"']*
     ['"]? # end quote
     )
-""", re.VERBOSE | re.UNICODE)
+""",
+    re.VERBOSE | re.UNICODE,
+)
 
 
 @register.tag
@@ -144,7 +156,10 @@ def render_field(parser, token):
     attribute=value or attribute="a value" for assignment and attribute+=value
     or attribute+="value" for appending.
     """
-    error_msg = '%r tag requires a form field followed by a list of attributes and values in the form attr="value"' % token.split_contents()[0]
+    error_msg = (
+        '%r tag requires a form field followed by a list of attributes and values in the form attr="value"'
+        % token.split_contents()[0]
+    )
     try:
         bits = token.split_contents()
         tag_name = bits[0]
@@ -162,8 +177,11 @@ def render_field(parser, token):
         if not match:
             raise TemplateSyntaxError(error_msg + ": %s" % pair)
         dct = match.groupdict()
-        attr, sign, value = \
-            dct['attr'], dct['sign'], parser.compile_filter(dct['value'])
+        attr, sign, value = (
+            dct["attr"],
+            dct["sign"],
+            parser.compile_filter(dct["value"]),
+        )
         if sign == "=":
             set_attrs.append((attr, value))
         else:
@@ -180,29 +198,31 @@ class FieldAttributeNode(Node):
 
     def render(self, context):
         bounded_field = self.field.resolve(context)
-        field = getattr(bounded_field, 'field', None)
-        if (
-            getattr(bounded_field, 'errors', None) and
-            'WIDGET_ERROR_CLASS' in context
-        ):
-            bounded_field = append_attr(bounded_field, 'class:%s' %
-                                        context['WIDGET_ERROR_CLASS'])
-        if field and field.required and 'WIDGET_REQUIRED_CLASS' in context:
-            bounded_field = append_attr(bounded_field, 'class:%s' %
-                                        context['WIDGET_REQUIRED_CLASS'])
+        field = getattr(bounded_field, "field", None)
+        if getattr(bounded_field, "errors", None) and "WIDGET_ERROR_CLASS" in context:
+            bounded_field = append_attr(
+                bounded_field, "class:%s" % context["WIDGET_ERROR_CLASS"]
+            )
+        if field and field.required and "WIDGET_REQUIRED_CLASS" in context:
+            bounded_field = append_attr(
+                bounded_field, "class:%s" % context["WIDGET_REQUIRED_CLASS"]
+            )
         for k, v in self.set_attrs:
-            if k == 'type':
+            if k == "type":
                 bounded_field.field.widget.input_type = v.resolve(context)
             else:
-                bounded_field = \
-                    set_attr(bounded_field, '%s:%s' % (k, v.resolve(context)))
+                bounded_field = set_attr(
+                    bounded_field, "%s:%s" % (k, v.resolve(context))
+                )
         for k, v in self.append_attrs:
-            bounded_field = \
-                append_attr(bounded_field, '%s:%s' % (k, v.resolve(context)))
+            bounded_field = append_attr(
+                bounded_field, "%s:%s" % (k, v.resolve(context))
+            )
         return str(bounded_field)
 
 
 # ======================== remove_attr tag ==============================
+
 
 @register.filter("remove_attr")
 @silence_without_field

--- a/widget_tweaks/tests.py
+++ b/widget_tweaks/tests.py
@@ -20,19 +20,18 @@ except ImportError:
 #       Testing helpers
 # ==============================
 
+
 class MyForm(Form):
     """
     Test form. If you want to test rendering of a field,
     add it to this form and use one of 'render_...' functions
     from this module.
     """
+
     simple = CharField()
-    with_attrs = CharField(widget=TextInput(attrs={
-        'foo': 'baz',
-        'egg': 'spam'
-    }))
-    with_cls = CharField(widget=TextInput(attrs={'class': 'class0'}))
-    date = forms.DateField(widget=SelectDateWidget(attrs={'egg': 'spam'}))
+    with_attrs = CharField(widget=TextInput(attrs={"foo": "baz", "egg": "spam"}))
+    with_cls = CharField(widget=TextInput(attrs={"class": "class0"}))
+    date = forms.DateField(widget=SelectDateWidget(attrs={"egg": "spam"}))
 
 
 def render_form(text, form=None, **context_args):
@@ -41,7 +40,7 @@ def render_form(text, form=None, **context_args):
     and MyForm instance available in context as ``form``.
     """
     tpl = Template("{% load widget_tweaks %}" + text)
-    context_args.update({'form': MyForm() if form is None else form})
+    context_args.update({"form": MyForm() if form is None else form})
     context = Context(context_args)
     return tpl.render(context)
 
@@ -59,8 +58,8 @@ def render_field(field, template_filter, params, *args, **kwargs):
     """
     filters = [(template_filter, params)]
     filters.extend(zip(args[::2], args[1::2]))
-    filter_strings = ['|%s:"%s"' % (f[0], f[1],) for f in filters]
-    render_field_str = '{{ form.%s%s }}' % (field, ''.join(filter_strings))
+    filter_strings = ['|%s:"%s"' % (f[0], f[1]) for f in filters]
+    render_field_str = "{{ form.%s%s }}" % (field, "".join(filter_strings))
     return render_form(render_field_str, **kwargs)
 
 
@@ -69,34 +68,35 @@ def render_field_from_tag(field, *attributes):
     Renders MyForm's field ``field`` with attributes passed
     as positional arguments.
     """
-    attr_strings = [' %s' % f for f in attributes]
-    tpl = string.Template('{% render_field form.$field$attrs %}')
-    render_field_str = tpl.substitute(field=field, attrs=''.join(attr_strings))
+    attr_strings = [" %s" % f for f in attributes]
+    tpl = string.Template("{% render_field form.$field$attrs %}")
+    render_field_str = tpl.substitute(field=field, attrs="".join(attr_strings))
     return render_form(render_field_str)
 
 
 def assertIn(value, obj):
-    assert value in obj, "%s not in %s" % (value, obj,)
+    assert value in obj, "%s not in %s" % (value, obj)
 
 
 def assertNotIn(value, obj):
-    assert value not in obj, "%s in %s" % (value, obj,)
+    assert value not in obj, "%s in %s" % (value, obj)
 
 
 # ===============================
 #           Test cases
 # ===============================
 
+
 class SimpleAttrTest(TestCase):
     def test_attr(self):
-        res = render_field('simple', 'attr', 'foo:bar')
+        res = render_field("simple", "attr", "foo:bar")
         assertIn('type="text"', res)
         assertIn('name="simple"', res)
         assertIn('id="id_simple"', res)
         assertIn('foo="bar"', res)
 
     def test_attr_chaining(self):
-        res = render_field('simple', 'attr', 'foo:bar', 'attr', 'bar:baz')
+        res = render_field("simple", "attr", "foo:bar", "attr", "bar:baz")
         assertIn('type="text"', res)
         assertIn('name="simple"', res)
         assertIn('id="id_simple"', res)
@@ -104,142 +104,149 @@ class SimpleAttrTest(TestCase):
         assertIn('bar="baz"', res)
 
     def test_add_class(self):
-        res = render_field('simple', 'add_class', 'foo')
+        res = render_field("simple", "add_class", "foo")
         assertIn('class="foo"', res)
 
     def test_add_multiple_classes(self):
-        res = render_field('simple', 'add_class', 'foo bar')
+        res = render_field("simple", "add_class", "foo bar")
         assertIn('class="foo bar"', res)
 
     def test_add_class_chaining(self):
-        res = render_field('simple', 'add_class', 'foo', 'add_class', 'bar')
+        res = render_field("simple", "add_class", "foo", "add_class", "bar")
         assertIn('class="bar foo"', res)
 
     def test_set_data(self):
-        res = render_field('simple', 'set_data', 'key:value')
+        res = render_field("simple", "set_data", "key:value")
         assertIn('data-key="value"', res)
 
     def test_replace_type(self):
-        res = render_field('simple', 'attr', 'type:date')
+        res = render_field("simple", "attr", "type:date")
         self.assertTrue(res.count("type=") == 1, (res, res.count("type=")))
         assertIn('type="date"', res)
 
     def test_replace_hidden(self):
-        res = render_field('simple', 'attr', 'type:hidden')
+        res = render_field("simple", "attr", "type:hidden")
         self.assertTrue(res.count("type=") == 1, (res, res.count("type=")))
         assertIn('type="hidden"', res)
 
 
 class ErrorsTest(TestCase):
-
     def _err_form(self):
-        form = MyForm({'foo': 'bar'})  # some random data
+        form = MyForm({"foo": "bar"})  # some random data
         form.is_valid()  # trigger form validation
         return form
 
     def test_error_class_no_error(self):
-        res = render_field('simple', 'add_error_class', 'err')
+        res = render_field("simple", "add_error_class", "err")
         assertNotIn('class="err"', res)
 
     def test_error_class_error(self):
         form = self._err_form()
-        res = render_field('simple', 'add_error_class', 'err', form=form)
+        res = render_field("simple", "add_error_class", "err", form=form)
         assertIn('class="err"', res)
 
     def test_error_attr_no_error(self):
-        res = render_field('simple', 'add_error_attr', 'aria-invalid:true')
+        res = render_field("simple", "add_error_attr", "aria-invalid:true")
         assertNotIn('aria-invalid="true"', res)
 
     def test_error_attr_error(self):
         form = self._err_form()
-        res = render_field('simple', 'add_error_attr', 'aria-invalid:true', form=form)
+        res = render_field("simple", "add_error_attr", "aria-invalid:true", form=form)
         assertIn('aria-invalid="true"', res)
 
 
 class SilenceTest(TestCase):
     def test_silence_without_field(self):
-        res = render_field("nothing", 'attr', 'foo:bar')
+        res = render_field("nothing", "attr", "foo:bar")
         self.assertEqual(res, "")
-        res = render_field("nothing", 'add_class', 'some')
+        res = render_field("nothing", "add_class", "some")
         self.assertEqual(res, "")
-        res = render_field("nothing", 'remove_attr', 'some')
+        res = render_field("nothing", "remove_attr", "some")
         self.assertEqual(res, "")
 
 
 class CustomizedWidgetTest(TestCase):
     def test_attr(self):
-        res = render_field('with_attrs', 'attr', 'foo:bar')
+        res = render_field("with_attrs", "attr", "foo:bar")
         assertIn('foo="bar"', res)
         assertNotIn('foo="baz"', res)
         assertIn('egg="spam"', res)
 
     # XXX can be dropped once 1.8 is not supported
-    @skipIf(VERSION < (1, 11, 0, 'final', 0), 'see https://code.djangoproject.com/ticket/16754')
+    @skipIf(
+        VERSION < (1, 11, 0, "final", 0),
+        "see https://code.djangoproject.com/ticket/16754",
+    )
     def test_selectdatewidget(self):
-        res = render_field('date', 'attr', 'foo:bar')
+        res = render_field("date", "attr", "foo:bar")
         assertIn('egg="spam"', res)
         assertIn('foo="bar"', res)
 
     def test_attr_chaining(self):
-        res = render_field('with_attrs', 'attr', 'foo:bar', 'attr', 'bar:baz')
+        res = render_field("with_attrs", "attr", "foo:bar", "attr", "bar:baz")
         assertIn('foo="bar"', res)
         assertNotIn('foo="baz"', res)
         assertIn('egg="spam"', res)
         assertIn('bar="baz"', res)
 
     def test_attr_class(self):
-        res = render_field('with_cls', 'attr', 'foo:bar')
+        res = render_field("with_cls", "attr", "foo:bar")
         assertIn('foo="bar"', res)
         assertIn('class="class0"', res)
 
     def test_default_attr(self):
-        res = render_field('with_cls', 'attr', 'type:search')
+        res = render_field("with_cls", "attr", "type:search")
         assertIn('class="class0"', res)
         assertIn('type="search"', res)
 
     def test_add_class(self):
-        res = render_field('with_cls', 'add_class', 'class1')
-        assertIn('class0', res)
-        assertIn('class1', res)
+        res = render_field("with_cls", "add_class", "class1")
+        assertIn("class0", res)
+        assertIn("class1", res)
 
     def test_add_class_chaining(self):
-        res = render_field('with_cls', 'add_class', 'class1', 'add_class', 'class2')
-        assertIn('class0', res)
-        assertIn('class1', res)
-        assertIn('class2', res)
+        res = render_field("with_cls", "add_class", "class1", "add_class", "class2")
+        assertIn("class0", res)
+        assertIn("class1", res)
+        assertIn("class2", res)
 
     def test_remove_attr(self):
-        res = render_field('with_attrs', 'remove_attr', 'foo')
-        assertNotIn('foo', res)
+        res = render_field("with_attrs", "remove_attr", "foo")
+        assertNotIn("foo", res)
 
 
 class FieldReuseTest(TestCase):
-
     def test_field_double_rendering_simple(self):
-        res = render_form('{{ form.simple }}{{ form.simple|attr:"foo:bar" }}{{ form.simple }}')
+        res = render_form(
+            '{{ form.simple }}{{ form.simple|attr:"foo:bar" }}{{ form.simple }}'
+        )
         self.assertEqual(res.count("bar"), 1)
 
     def test_field_double_rendering_simple_css(self):
-        res = render_form('{{ form.simple }}{{ form.simple|add_class:"bar" }}{{ form.simple|add_class:"baz" }}')
+        res = render_form(
+            '{{ form.simple }}{{ form.simple|add_class:"bar" }}{{ form.simple|add_class:"baz" }}'
+        )
         self.assertEqual(res.count("baz"), 1)
         self.assertEqual(res.count("bar"), 1)
 
     def test_field_double_rendering_attrs(self):
-        res = render_form('{{ form.with_cls }}{{ form.with_cls|add_class:"bar" }}{{ form.with_cls }}')
+        res = render_form(
+            '{{ form.with_cls }}{{ form.with_cls|add_class:"bar" }}{{ form.with_cls }}'
+        )
         self.assertEqual(res.count("class0"), 3)
         self.assertEqual(res.count("bar"), 1)
 
 
 class SimpleRenderFieldTagTest(TestCase):
     def test_attr(self):
-        res = render_field_from_tag('simple', 'foo="bar"')
+        res = render_field_from_tag("simple", 'foo="bar"')
         assertIn('type="text"', res)
         assertIn('name="simple"', res)
         assertIn('id="id_simple"', res)
         assertIn('foo="bar"', res)
 
     def test_multiple_attrs(self):
-        res = render_field_from_tag('simple', 'foo="bar"', 'bar="baz"')
+        res = render_field_from_tag("simple", 'foo="bar"', 'bar="baz"')
         assertIn('type="text"', res)
         assertIn('name="simple"', res)
         assertIn('id="id_simple"', res)
@@ -257,92 +264,111 @@ class RenderFieldTagSilenceTest(TestCase):
 
 class RenderFieldTagCustomizedWidgetTest(TestCase):
     def test_attr(self):
-        res = render_field_from_tag('with_attrs', 'foo="bar"')
+        res = render_field_from_tag("with_attrs", 'foo="bar"')
         assertIn('foo="bar"', res)
         assertNotIn('foo="baz"', res)
         assertIn('egg="spam"', res)
 
     # XXX can be dropped once 1.8 is not supported
-    @skipIf(VERSION < (1, 11, 0, 'final', 0), 'see https://code.djangoproject.com/ticket/16754')
+    @skipIf(
+        VERSION < (1, 11, 0, "final", 0),
+        "see https://code.djangoproject.com/ticket/16754",
+    )
     def test_selectdatewidget(self):
-        res = render_field_from_tag('date', 'foo="bar"')
+        res = render_field_from_tag("date", 'foo="bar"')
         assertIn('egg="spam"', res)
         assertIn('foo="bar"', res)
 
     def test_multiple_attrs(self):
-        res = render_field_from_tag('with_attrs', 'foo="bar"', 'bar="baz"')
+        res = render_field_from_tag("with_attrs", 'foo="bar"', 'bar="baz"')
         assertIn('foo="bar"', res)
         assertNotIn('foo="baz"', res)
         assertIn('egg="spam"', res)
         assertIn('bar="baz"', res)
 
     def test_attr_class(self):
-        res = render_field_from_tag('with_cls', 'foo="bar"')
+        res = render_field_from_tag("with_cls", 'foo="bar"')
         assertIn('foo="bar"', res)
         assertIn('class="class0"', res)
 
     def test_default_attr(self):
-        res = render_field_from_tag('with_cls', 'type="search"')
+        res = render_field_from_tag("with_cls", 'type="search"')
         assertIn('class="class0"', res)
         assertIn('type="search"', res)
 
     def test_append_attr(self):
-        res = render_field_from_tag('with_cls', 'class+="class1"')
-        assertIn('class0', res)
-        assertIn('class1', res)
+        res = render_field_from_tag("with_cls", 'class+="class1"')
+        assertIn("class0", res)
+        assertIn("class1", res)
 
     def test_duplicate_append_attr(self):
-        res = render_field_from_tag('with_cls', 'class+="class1"', 'class+="class2"')
-        assertIn('class0', res)
-        assertIn('class1', res)
-        assertIn('class2', res)
+        res = render_field_from_tag("with_cls", 'class+="class1"', 'class+="class2"')
+        assertIn("class0", res)
+        assertIn("class1", res)
+        assertIn("class2", res)
 
     def test_hyphenated_attributes(self):
-        res = render_field_from_tag('with_cls', 'data-foo="bar"')
+        res = render_field_from_tag("with_cls", 'data-foo="bar"')
         assertIn('data-foo="bar"', res)
         assertIn('class="class0"', res)
 
 
 class RenderFieldWidgetClassesTest(TestCase):
     def test_use_widget_required_class(self):
-        res = render_form('{% render_field form.simple %}',
-                          WIDGET_REQUIRED_CLASS='required_class')
+        res = render_form(
+            "{% render_field form.simple %}", WIDGET_REQUIRED_CLASS="required_class"
+        )
         assertIn('class="required_class"', res)
 
     def test_use_widget_error_class(self):
-        res = render_form('{% render_field form.simple %}', form=MyForm({}),
-                          WIDGET_ERROR_CLASS='error_class')
+        res = render_form(
+            "{% render_field form.simple %}",
+            form=MyForm({}),
+            WIDGET_ERROR_CLASS="error_class",
+        )
         assertIn('class="error_class"', res)
 
     def test_use_widget_error_class_with_other_classes(self):
-        res = render_form('{% render_field form.simple class="blue" %}',
-                          form=MyForm({}), WIDGET_ERROR_CLASS='error_class')
+        res = render_form(
+            '{% render_field form.simple class="blue" %}',
+            form=MyForm({}),
+            WIDGET_ERROR_CLASS="error_class",
+        )
         assertIn('class="blue error_class"', res)
 
     def test_use_widget_required_class_with_other_classes(self):
-        res = render_form('{% render_field form.simple class="blue" %}',
-                          form=MyForm({}), WIDGET_REQUIRED_CLASS='required_class')
+        res = render_form(
+            '{% render_field form.simple class="blue" %}',
+            form=MyForm({}),
+            WIDGET_REQUIRED_CLASS="required_class",
+        )
         assertIn('class="blue required_class"', res)
 
 
 class RenderFieldTagFieldReuseTest(TestCase):
     def test_field_double_rendering_simple(self):
-        res = render_form('{{ form.simple }}{% render_field form.simple foo="bar" %}{% render_field form.simple %}')
+        res = render_form(
+            '{{ form.simple }}{% render_field form.simple foo="bar" %}{% render_field form.simple %}'
+        )
         self.assertEqual(res.count("bar"), 1)
 
     def test_field_double_rendering_simple_css(self):
-        res = render_form('{% render_field form.simple %}{% render_field form.simple class+="bar" %}{% render_field form.simple class+="baz" %}')
+        res = render_form(
+            '{% render_field form.simple %}{% render_field form.simple class+="bar" %}{% render_field form.simple class+="baz" %}'
+        )
         self.assertEqual(res.count("baz"), 1)
         self.assertEqual(res.count("bar"), 1)
 
     def test_field_double_rendering_attrs(self):
-        res = render_form('{% render_field form.with_cls %}{% render_field form.with_cls class+="bar" %}{% render_field form.with_cls %}')
+        res = render_form(
+            '{% render_field form.with_cls %}{% render_field form.with_cls class+="bar" %}{% render_field form.with_cls %}'
+        )
         self.assertEqual(res.count("class0"), 3)
         self.assertEqual(res.count("bar"), 1)
 
     def test_field_double_rendering_id(self):
         res = render_form(
-            '{{ form.simple }}'
+            "{{ form.simple }}"
             '{% render_field form.simple id="id_1" %}'
             '{% render_field form.simple id="id_2" %}'
         )
@@ -351,7 +377,7 @@ class RenderFieldTagFieldReuseTest(TestCase):
 
     def test_field_double_rendering_id_name(self):
         res = render_form(
-            '{{ form.simple }}'
+            "{{ form.simple }}"
             '{% render_field form.simple id="id_1" name="n_1" %}'
             '{% render_field form.simple id="id_2" name="n_2" %}'
         )
@@ -362,7 +388,7 @@ class RenderFieldTagFieldReuseTest(TestCase):
 
     def test_field_double_rendering_id_class(self):
         res = render_form(
-            '{{ form.simple }}'
+            "{{ form.simple }}"
             '{% render_field form.simple id="id_1" class="c_1" %}'
             '{% render_field form.simple id="id_2" class="c_2" %}'
         )
@@ -373,7 +399,7 @@ class RenderFieldTagFieldReuseTest(TestCase):
 
     def test_field_double_rendering_name_class(self):
         res = render_form(
-            '{{ form.simple }}'
+            "{{ form.simple }}"
             '{% render_field form.simple name="n_1" class="c_1" %}'
             '{% render_field form.simple name="n_2" class="c_2" %}'
         )
@@ -385,22 +411,26 @@ class RenderFieldTagFieldReuseTest(TestCase):
 
 class RenderFieldTagUseTemplateVariableTest(TestCase):
     def test_use_template_variable_in_parametrs(self):
-        res = render_form('{% render_field form.with_attrs egg+="pahaz" placeholder=form.with_attrs.label %}')
+        res = render_form(
+            '{% render_field form.with_attrs egg+="pahaz" placeholder=form.with_attrs.label %}'
+        )
         assertIn('egg="spam pahaz"', res)
         assertIn('placeholder="With attrs"', res)
 
 
 class RenderFieldFilter_field_type_widget_type_Test(TestCase):
     def test_field_type_widget_type_rendering_simple(self):
-        res = render_form('<div class="{{ form.simple|field_type }} {{ form.simple|widget_type }} {{ form.simple.html_name }}">{{ form.simple }}</div>')
+        res = render_form(
+            '<div class="{{ form.simple|field_type }} {{ form.simple|widget_type }} {{ form.simple.html_name }}">{{ form.simple }}</div>'
+        )
         assertIn('class="charfield textinput simple"', res)
 
 
 class RenderFieldTagNonValueAttribute(TestCase):
     def test_field_non_value(self):
         res = render_form('{{ form.simple|attr:"foo" }}')
-        assertIn('foo', res)
-        assertNotIn('foo=', res)
+        assertIn("foo", res)
+        assertNotIn("foo=", res)
 
     def test_field_empty_value(self):
         res = render_form('{{ form.simple|attr:"foo:" }}')
@@ -417,9 +447,11 @@ class RenderFieldTagNonValueAttribute(TestCase):
     def test_field_double_colon_morethanone(self):
         res = render_form('{{ form.simple|attr:"v-bind::class:{active:True}" }}')
         assertIn('v-bind:class="{active:True}"', res)
+
     def test_field_arroba(self):
         res = render_form('{{ form.simple|attr:"@click:onClick" }}')
         assertIn('@click="onClick"', res)
+
     def test_field_arroba_dot(self):
         res = render_form('{{ form.simple|attr:"@click.prevent:onClick" }}')
         assertIn('@click.prevent="onClick"', res)
@@ -427,4 +459,3 @@ class RenderFieldTagNonValueAttribute(TestCase):
     def test_field_double_colon_missing(self):
         res = render_form('{{ form.simple|attr:"::class:{active:True}" }}')
         assertIn(':class="{active:True}"', res)
-


### PR DESCRIPTION
Relates to discussion in #63 and #83

More on code formatting philosophy at https://www.mattlayman.com/blog/2018/python-code-black/