### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Unreleased
+----------
+
+* Removed usage of pkg_resource to avoid derecation
+  warnings. If you want to inspect the installed version,
+  use ``importlib.metadata.version("django-widget-tweaks")``
+  (`docs <https://docs.python.org/3.8/library/importlib.metadata.html#distribution-versions>`__ /
+  `backport <https://pypi.org/project/importlib-metadata/>`__).
 
 1.4.12 (2022-01-13)
 -------------------

--- a/widget_tweaks/__init__.py
+++ b/widget_tweaks/__init__.py
@@ -1,7 +1,0 @@
-from pkg_resources import get_distribution, DistributionNotFound
-
-try:
-    __version__ = get_distribution("django-widget-tweaks").version
-except DistributionNotFound:
-    # package is not installed
-    __version__ = None


### PR DESCRIPTION
pkg_resources is deprecated and emits warning messages.

Fixes #131