### PR TITLE
Fix re.split deprecation warning

### DIFF
--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -19,7 +19,7 @@ def _process_field_attributes(field, attr, process):
     # split attribute name and value from 'attr:value' string
     # params = attr.split(':', 1)
     # attribute = params[0]
-    params = re.split(r"(?<!:):(?!:)", attr, 1)
+    params = re.split(r"(?<!:):(?!:)", attr, maxsplit=1)
     # attribute = params[0]
     attribute = params[0].replace("::", ":")
     value = params[1] if len(params) == 2 else True


### PR DESCRIPTION
From https://docs.python.org/3/library/re.html#re.split:

> re.split(pattern, string, maxsplit=0, flags=0)
> Deprecated since version 3.13: Passing maxsplit and flags as positional arguments is deprecated. In future Python versions they will be [keyword-only parameters](https://docs.python.org/3/glossary.html#keyword-only-parameter).

Fixes #150. Let me know if it needs anything else.