### PR TITLE
fix: handle complex attribute values with quotes and braces in render_field

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -397,6 +397,53 @@ class RenderFieldTagNonValueAttribute(TestCase):
         assertIn(':class="{active:True}"', res)
 
 
+class RenderFieldTagComplexAttributeValuesTest(TestCase):
+    """Tests for complex attribute values with quotes and braces (gh-160, gh-153)."""
+
+    def test_double_colon_with_curly_braces(self):
+        # ::class="{'is-invalid': isInvalid}" should not raise TemplateSyntaxError
+        res = render_field_from_tag(
+            "simple",
+            '::class="{\'is-invalid\': isInvalid}"',
+        )
+        self.assertIn('is-invalid', res)
+        self.assertIn('class', res)
+
+    def test_alpine_x_bind_with_ternary(self):
+        # x-bind::type="show ? 'text' : 'password'" should not raise
+        res = render_field_from_tag(
+            "simple",
+            'x-bind::type="show ? \'text\' : \'password\'"',
+        )
+        self.assertIn('show ?', res)
+        self.assertNotIn('error', res.lower())
+
+    def test_single_quoted_value_with_double_quotes_inside(self):
+        # data-config='{"key": "value"}' should not raise
+        res = render_field_from_tag(
+            "simple",
+            "data-config='{\"key\": \"value\"}'",
+        )
+        self.assertIn('key', res)
+        self.assertNotIn('error', res.lower())
+
+    def test_simple_standard_attributes_still_work(self):
+        res = render_field_from_tag("simple", 'class="form-control"')
+        self.assertIn('class="form-control"', res)
+
+    def test_appending_attribute_with_complex_value(self):
+        res = render_field_from_tag("simple", 'class+="btn btn-primary"')
+        self.assertIn('class="btn btn-primary"', res)
+
+    def test_simple_standard_attributes_still_work(self):
+        res = render_field_from_tag("simple", 'class="form-control"')
+        self.assertIn('class="form-control"', res)
+
+    def test_appending_attribute_with_complex_value(self):
+        res = render_field_from_tag("simple", 'class+="btn btn-primary"')
+        self.assertIn('class="btn btn-primary"', res)
+
+
 class SelectFieldTest(TestCase):
     def test_parent_field(self):
         res = render_field("choice", "attr", "foo:bar")

--- a/widget_tweaks/templatetags/widget_tweaks.py
+++ b/widget_tweaks/templatetags/widget_tweaks.py
@@ -159,9 +159,11 @@ ATTRIBUTE_RE = re.compile(
         \+?=
     )
     (?P<value>
-    ['"]? # start quote
-        [^"']*
-    ['"]? # end quote
+        ["][^"]*["]       # Double-quoted string
+        |
+        [\'][^\']*[\']    # Single-quoted string
+        |
+        [^\s"'=]+         # Unquoted value
     )
 """,
     re.VERBOSE | re.UNICODE,


### PR DESCRIPTION
## Summary

Fixes #153 and #160.

The `ATTRIBUTE_RE` regex used in `{% render_field %}` could not handle attribute values containing both single and double quotes. This broke Alpine.js bindings and similar expressions:

- `::class="{'is-invalid': isInvalid}"` → `TemplateSyntaxError`
- `x-bind::type="show ? 'text' : 'password'"` → `TemplateSyntaxError`
- `data-config='{"key": "value"}'` → `TemplateSyntaxError`

## Root cause

The old value pattern `['"]?[^"']*['"]?` stopped matching at the first inner quote, producing a truncated value that Django's `compile_filter` could not parse.

## Fix

Replace the value group with three explicit alternatives:

| Branch | Matches | Inner quotes allowed |
|---|---|---|
| Double-quoted `"..."` | `"{\'is-invalid\': isInvalid}"` | single quotes |
| Single-quoted `'...'` | `'{"key": "value"}'` | double quotes |
| Unquoted `[^\s"'=]+` | `true`, `bar` | none |

## Tests

New `RenderFieldTagComplexAttributeValuesTest` class with 5 test methods covering:

- Double-colon Alpine.js bindings with single-quoted object keys
- Alpine.js ternary bindings with nested quotes
- Single-quoted values containing JSON (double quotes)
- Standard `class="form-control"` backward compat
- Append syntax `class+="btn btn-primary"` backward compat

All 68 tests pass.

```
$ python -m django test tests --settings=tests.settings -v 0
----------------------------------------------------------------------
Ran 68 tests in 0.029s
OK
```